### PR TITLE
Update github actions regex to support dev releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
     tags:
-      - "^v?[0-9]+.[0-9]+.[0-9]+"
+      - "^v?[0-9]+.[0-9]+.[0-9]+.*$"
   # pull_request:
 env:
   PLATFORMS: linux/amd64


### PR DESCRIPTION
This PR updates the regex used in github actions flow to build the docker images. It will support dev releases as well.