### PR TITLE
feat: set DNS cache property for JVM

### DIFF
--- a/opt/cruise-control/start.sh
+++ b/opt/cruise-control/start.sh
@@ -6,4 +6,8 @@ cd /opt/cruise-control
 if [ -z "${KAFKA_HEAP_OPTS}" ]; then
   export KAFKA_HEAP_OPTS="-XX:InitialRAMPercentage=75 -XX:MinRAMPercentage=75 -XX:MaxRAMPercentage=75"
 fi
+
+if [ -z "${KAFKA_OPTS}" ]; then
+  export KAFKA_OPTS="-Dsun.net.inetaddr.ttl=60"
+fi
 /bin/bash ${DEBUG:+-x} /opt/cruise-control/kafka-cruise-control-start.sh /opt/cruise-control/config/cruisecontrol.properties 8090


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0

### What's in this PR?
Make sure that JVM is configured to cache successful DNS lookups only for 60s. This helps to prevent stalled DNS cache entries in dynamic environments where hosts/containers frequently come and go.
