### PR TITLE
fix: CLASSPATH variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN \
   && npm run build
 
 FROM adoptopenjdk:11.0.8_10-jre-hotspot
-ENV CRUISE_CONTROL_LIBS=/var/lib/cruise-control-ext-libs
+ENV CRUISE_CONTROL_LIBS="/var/lib/cruise-control-ext-libs/*"
 ENV CLASSPATH="${CRUISE_CONTROL_LIBS}"
 RUN \
   set -xe; \


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0

### What's in this PR?
Fix `CLASSPATH` variable, so Cruise Control start up script properly detects additional files to be loaded.

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)