### PR TITLE
feat: add Cruise Control version 2.5.37

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM adoptopenjdk:11.0.10_9-jdk-hotspot as cruisecontrol
-ARG VERSION=2.5.34
+ARG VERSION=2.5.37
 WORKDIR /
 USER root
 RUN \


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
Add Cruise Control version 2.5.37 which adds support for Kafka 2.7 and uses Log4j2 for logging.

### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)