### PR TITLE
feat: add Cruise Control version 2.5.78

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM eclipse-temurin:11.0.13_8-jdk as cruisecontrol
-ARG VERSION=2.5.75
+ARG VERSION=2.5.78
 WORKDIR /
 USER root
 RUN \


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Bump Cruise Control version to 2.5.78 to get around CVE-2021-44228

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The current Cruise Control version is affected by log4j CVE-2021-44228

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)
